### PR TITLE
Add Django 5.2 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,8 @@ jobs:
         with:
           path: dist/*
 
-  pytest-python:
-    name: PyTest
+  pytest-django-lts:
+    name: PyTest Django LTS
     needs:
       - lint
     strategy:
@@ -51,9 +51,10 @@ jobs:
         python-version:
           - "3.9"
           - "3.10"
-          - "3.12"
+          - "3.11"
         django-version:
           - "4.2"  # LTS
+          - "5.2"  # LTS
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -70,18 +71,18 @@ jobs:
           flags: py${{ matrix.python-version }}
 
   pytest-django:
-    name: PyTest
+    name: PyTest Django
     needs:
       - lint
     strategy:
       matrix:
         python-version:
-          - "3.11"
+          - "3.12"
         django-version:
-          # LTS gets tested on all OS
-          - "3.2"
+          # LTS gets tested on all Python versions
           - "4.2"
-          - "5.0"
+          - "5.1"
+          - "5.2"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -99,7 +100,7 @@ jobs:
 
   codeql:
     name: CodeQL
-    needs: [ dist, pytest-python, pytest-django ]
+    needs: [ dist, pytest-django-lts, pytest-django ]
     runs-on: ubuntu-latest
     permissions:
       actions: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,8 @@ jobs:
         with:
           path: dist/*
 
-  pytest-django-lts:
-    name: PyTest Django LTS
+  pytest-python:
+    name: PyTest
     needs:
       - lint
     strategy:
@@ -52,9 +52,9 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
+          - "3.12"
         django-version:
           - "4.2"  # LTS
-          - "5.2"  # LTS
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -71,16 +71,15 @@ jobs:
           flags: py${{ matrix.python-version }}
 
   pytest-django:
-    name: PyTest Django
+    name: PyTest
     needs:
       - lint
     strategy:
       matrix:
         python-version:
-          - "3.12"
+          - "3.11"
         django-version:
-          # LTS gets tested on all Python versions
-          - "4.2"
+          # oldest LTS gets tested on all Python versions
           - "5.1"
           - "5.2"
     runs-on: ubuntu-latest
@@ -100,7 +99,7 @@ jobs:
 
   codeql:
     name: CodeQL
-    needs: [ dist, pytest-django-lts, pytest-django ]
+    needs: [ dist, pytest-python, pytest-django ]
     runs-on: ubuntu-latest
     permissions:
       actions: read

--- a/django_esm/finders.py
+++ b/django_esm/finders.py
@@ -1,5 +1,6 @@
 import functools
 import json
+import warnings
 
 from django.conf import settings
 from django.contrib.staticfiles.finders import BaseFinder
@@ -29,9 +30,25 @@ class ESMFinder(BaseFinder):
             ]
         return []
 
-    def find(self, path, all=False):
+    def _check_deprecated_find_param(self, find_all=False, **kwargs):
+        if "all" in kwargs:
+            warnings.warn(
+                "The 'all' argument of the find() method is deprecated in favor of "
+                "the 'find_all' argument.",
+                category=DeprecationWarning,
+                stacklevel=2,
+            )
+            find_all = kwargs["all"]
+        return find_all
+
+    # RemovedInDjango61Warning: When the deprecation ends, replace with:
+    # def find(self, path, find_all=False):
+    def find(self, path, find_all=False, **kwargs):
+        if kwargs:
+            find_all = self._check_deprecated_find_param(find_all=find_all, **kwargs)
+        
         if path in self.all:
-            return [path] if all else path
+            return [path] if find_all else path
         return []  # this method has a strange return type
 
     def list(self, ignore_patterns):

--- a/django_esm/finders.py
+++ b/django_esm/finders.py
@@ -30,23 +30,29 @@ class ESMFinder(BaseFinder):
             ]
         return []
 
-    def _check_deprecated_find_param(self, find_all=False, **kwargs):
-        if "all" in kwargs:
-            warnings.warn(
-                "The 'all' argument of the find() method is deprecated in favor of "
-                "the 'find_all' argument.",
-                category=DeprecationWarning,
-                stacklevel=2,
-            )
+    def _check_deprecated_find_param(self, find_all, **kwargs):
+        # @todo: remove this after Django 5.2 support is dropped
+        try:
             find_all = kwargs["all"]
+        except KeyError:
+            pass
+        else:
+            try:
+                from django.utils.deprecation import RemovedInDjango61Warning
+            except ImportError:
+                pass
+            else:
+                warnings.warn(
+                    "The 'all' argument of the find() method is deprecated in favor of "
+                    "the 'find_all' argument.",
+                    category=RemovedInDjango61Warning,
+                    stacklevel=2,
+                )
         return find_all
 
-    # RemovedInDjango61Warning: When the deprecation ends, replace with:
-    # def find(self, path, find_all=False):
     def find(self, path, find_all=False, **kwargs):
-        if kwargs:
-            find_all = self._check_deprecated_find_param(find_all=find_all, **kwargs)
-        
+        find_all = self._check_deprecated_find_param(find_all, **kwargs)
+
         if path in self.all:
             return [path] if find_all else path
         return []  # this method has a strange return type

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,9 +28,9 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Framework :: Django",
-  "Framework :: Django :: 3.2",
   "Framework :: Django :: 4.2",
-  "Framework :: Django :: 5.0",
+  "Framework :: Django :: 5.1",
+  "Framework :: Django :: 5.2",
 ]
 requires-python = ">=3.9"
 dependencies = ["django>=3.2.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
   "Framework :: Django :: 5.2",
 ]
 requires-python = ">=3.9"
-dependencies = ["django>=3.2.0"]
+dependencies = ["django>=4.2.0"]
 
 [project.optional-dependencies]
 test = [

--- a/tests/test_finders.py
+++ b/tests/test_finders.py
@@ -1,5 +1,6 @@
 from django.contrib.staticfiles.finders import get_finder
 from django.core.checks import Error
+import warnings
 
 from django_esm import storages
 
@@ -17,8 +18,18 @@ class TestESMFinder:
             self.finder.find("testapp/static/js/components/index.js")
             == "testapp/static/js/components/index.js"
         )
-        assert self.finder.find("lit-html/lit-html.js", all=True) == []
+        assert self.finder.find("lit-html/lit-html.js", find_all=True) == []
         assert self.finder.find("foo/bar.js") == []
+
+    def test_find_with_deprecated_param(self):
+        # Remove the test when Django 5.1 is no longer supported
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = self.finder.find("testapp/static/js/index.js", all=True)
+            assert len(w) == 1
+            assert issubclass(w[0].category, DeprecationWarning)
+            assert "deprecated in favor of" in str(w[0].message)
+            assert result == ["testapp/static/js/index.js"]
 
     def test_list(self):
         all_files = self.finder.list([])

--- a/tests/test_finders.py
+++ b/tests/test_finders.py
@@ -1,6 +1,7 @@
+import warnings
+
 from django.contrib.staticfiles.finders import get_finder
 from django.core.checks import Error
-import warnings
 
 from django_esm import storages
 

--- a/tests/test_finders.py
+++ b/tests/test_finders.py
@@ -1,5 +1,7 @@
 import warnings
 
+import django.utils.deprecation
+import pytest
 from django.contrib.staticfiles.finders import get_finder
 from django.core.checks import Error
 
@@ -22,13 +24,16 @@ class TestESMFinder:
         assert self.finder.find("lit-html/lit-html.js", find_all=True) == []
         assert self.finder.find("foo/bar.js") == []
 
+    @pytest.mark.skipif(
+        not hasattr(django.utils.deprecation, "RemovedInDjango61Warning"),
+        reason="Django < 5.2",
+    )
     def test_find_with_deprecated_param(self):
-        # Remove the test when Django 5.1 is no longer supported
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             result = self.finder.find("testapp/static/js/index.js", all=True)
             assert len(w) == 1
-            assert issubclass(w[0].category, DeprecationWarning)
+            assert w[0].category == django.utils.deprecation.RemovedInDjango61Warning
             assert "deprecated in favor of" in str(w[0].message)
             assert result == ["testapp/static/js/index.js"]
 


### PR DESCRIPTION
[Django 5.2](https://docs.djangoproject.com/en/5.2/releases/5.2/) introduced a deprecation:
>The all argument for the django.contrib.staticfiles.finders.find() function is deprecated in favor of the find_all argument.

I am addressing this, following the style used in Django's finders.py.

Together with that change, I updated the test matrix to support only [active Django releases](https://endoflife.date/django).
I also refactored confused CI job namings, but feel free to give a feedback/change these yourself.


🫶 
Rust