### PR TITLE
Add --treeshake flag to collectstatic command

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,12 +90,6 @@ project's own entry points, keeping only the outputs actually imported:
 python manage.py esm --watch --treeshake
 ```
 
-`collectstatic` accepts the same flag, so apply tree shaking during deployment:
-
-```bash
-python manage.py collectstatic --noinput --treeshake
-```
-
 ## Usage
 
 You can now import JavaScript modules in your Django templates:

--- a/README.md
+++ b/README.md
@@ -90,6 +90,12 @@ project's own entry points, keeping only the outputs actually imported:
 python manage.py esm --watch --treeshake
 ```
 
+`collectstatic` accepts the same flag, so apply tree shaking during deployment:
+
+```bash
+python manage.py collectstatic --noinput --treeshake
+```
+
 ## Usage
 
 You can now import JavaScript modules in your Django templates:

--- a/django_esm/management/commands/collectstatic.py
+++ b/django_esm/management/commands/collectstatic.py
@@ -15,6 +15,12 @@ class Command(collectstatic.Command):
             action="store_true",
             help="Do not collect ES modules before collecting static files.",
         )
+        parser.add_argument(
+            "--treeshake",
+            "-t",
+            action="store_true",
+            help="Drop unused entry points from the import map.",
+        )
 
     def handle(self, **options):
         if not options["no_esm"]:
@@ -26,6 +32,7 @@ class Command(collectstatic.Command):
                     get_settings().PACKAGE_DIR,
                     get_settings().STATIC_DIR,
                 ]
+                + (["--treeshake"] if options["treeshake"] else [])
                 + (["--verbose"] if options["verbosity"] > 1 else []),
                 stdout=sys.stdout if options["verbosity"] else subprocess.DEVNULL,
                 stderr=sys.stderr,

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -98,3 +98,24 @@ def test_collectstatic__noesm(monkeypatch):
     monkeypatch.setattr("subprocess.check_call", check_call)
     call_command("collectstatic", "--noesm", "--noinput")
     assert not check_call.called
+
+
+def test_collectstatic__treeshake(monkeypatch):
+    check_call = Mock()
+    monkeypatch.setattr("subprocess.check_call", check_call)
+    call_command("collectstatic", "--noinput", "--treeshake")
+    assert check_call.called
+    try:
+        import whitenoise  # noqa
+    except ImportError:
+        assert check_call.call_count == 1
+    else:
+        assert check_call.call_count == 2
+    assert check_call.call_args_list[0][0][0] == [
+        "npx",
+        "--yes",
+        "esimport",
+        get_settings().PACKAGE_DIR,
+        get_settings().STATIC_DIR,
+        "--treeshake",
+    ]


### PR DESCRIPTION
Fixes #107

PR #106 added `--treeshake` to the `esm` command, but `collectstatic` still invoked `esimport` without it. During deployment, `collectstatic` would rebuild the import map without tree shaking, re-adding the unused imports that `--treeshake` had removed.

## Changes

- **`django_esm/management/commands/collectstatic.py`** — Added `--treeshake`/`-t` argument (mirroring the `esm` command) and forwarded it to the `esimport` subprocess call.
- **`tests/test_commands.py`** — Added `test_collectstatic__treeshake` verifying the flag is passed to esimport.
- **`README.md`** — Documented that `collectstatic` also accepts `--treeshake` for deployment.

## Usage

```bash
python manage.py collectstatic --noinput --treeshake
```

## Test plan

- [x] `test_collectstatic__treeshake` — verifies esimport receives `--treeshake`
- [x] `test_collectstatic` — verifies default (no treeshake) still works
- [x] All command tests pass (`pytest tests/test_commands.py`)
- [x] Pre-commit hooks pass (ruff, ruff format, etc.)